### PR TITLE
 Updating Bacon2 function to allow higher rbacon #3 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,8 @@ Imports:
 Remotes: 
     earthsystemdiagnostics/hamstr
 RoxygenNote: 7.1.1
+Suggests: 
+     testthat,
+     knitr
+VignetteBuilder: knitr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hamstrbacon
 Type: Package
 Title: Interface Between the rbacon and hamstr packages
-Version: 0.1.0
+Version: 0.1.1
 Encoding: UTF-8
 Authors@R: c(person("Andrew", "Dolman", email = "andrew.dolman@awi.de", role = c("aut", "cre")))
 Description: hamstrbacon provides an interface between rbacon and hamstr so that Bacon models can be created and plotted using as similar interface to hamstr. "Blaauw, Maarten, and J. Andrés Christen. 2011. 'Flexible Paleoclimate   Age-Depth Models Using an Autoregressive Gamma Process.'  Bayesian Analysis 6 (3): 457-74. doi:10.1214/ba/1339616472"
@@ -12,12 +12,13 @@ Depends:
     R (>= 3.5.0)
 Imports: 
     hamstr,
-    rbacon (== 2.5.2),
-    magrittr
+    rbacon (>= 2.5.6),
+    magrittr,
+    dplyr,
+    ggplot2,
+    readr,
+    tidyr
 Remotes: 
     earthsystemdiagnostics/hamstr
 RoxygenNote: 7.1.1
-Suggests: 
-    testthat,
-    knitr
-VignetteBuilder: knitr
+

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -32,11 +32,9 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
   if (ccdir == "")
     ccdir <- system.file("extdata", package = "IntCal")
   
-  if (packageVersion("rbacon") > "2.5.3"){
-    ccdir <- rbacon:::validateDirectoryName(ccdir)
-  }  else {
-    ccdir <- rbacon:::.validateDirectoryName(ccdir)
-  }
+  # NOTE: validateDirectoryName was removed in newer rbacon versions.
+  # If needed, add your own ccdir sanitation here.
+  ccdir <- ccdir
   
   defaults <- system.file("extdata", defaults, package = packageName())
   dets <- read.dets(core, coredir, sep = sep, dec = dec, cc = cc)

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -139,9 +139,9 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
     info$rng <- range(info$rng, tmp[, 1])
   }
   if (length(th0) == 0)
-    info$th0 <- round(rnorm(2, max(MinAge, dets[1, 2]), dets[1,
+    info$th0 <- round(rnorm(2, max(info$d.min, dets[1, 2]), dets[1,
                                                              3]))
-  info$th0[info$th0 < info$MinAge] <- info$MinAge
+  info$th0[info$th0 < info$d.min] <- info$d.min
   if (length(depths) == 0)
     depths <- seq(info$d.min, info$d.max, by = d.by)
   if (depths.file) {

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -11,7 +11,7 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
                     ask = TRUE, run = TRUE, defaults = "defaultBacon_settings.txt",
                     sep = ",", dec = ".", runname = "", slump = c(),
                     remove = FALSE, BCAD = FALSE, ssize = 2000, th0 = c(),
-                    burnin = min(500, ssize), MinAge = c(), MaxAge = c(), MinYr = MinAge, MaxYr = MaxAge,
+                    burnin = min(500, ssize), youngest.age = c(), oldest.age = c(),
                     cutoff = 0.01, plot.pdf = TRUE, dark = 1, date.res = 100,
                     age.res = 200, yr.res = age.res, close.connections = TRUE,
                     verbose = TRUE, suppress.plots = TRUE, bacon.change.thick = FALSE,
@@ -101,8 +101,8 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
                          cc1 = cc1, cc2 = cc2, cc3 = cc3, cc4 = cc4, depth.unit = depth.unit,
                          normal = normal, t.a = t.a, t.b = t.b, delta.R = delta.R,
                          delta.STD = delta.STD, prob = prob, defaults = defaults,
-                         runname = runname, ssize = ssize, dark = dark, MinAge = MinAge,
-                         MaxAge = MaxAge, cutoff = cutoff, age.res = age.res,
+                         runname = runname, ssize = ssize, dark = dark, youngest.age = youngest.age,
+                         oldest.age = oldest.age, cutoff = cutoff, age.res = age.res,
                          after = after, age.unit = age.unit)
   assign_to_global("info", info)
   info$coredir <- coredir
@@ -325,8 +325,16 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
         cook()
       else message("  OK. Please adapt settings")
     }
-  if (close.connections)
-    closeAllConnections()
+  
+  if (close.connections) {
+    try({
+      conns <- showConnections(all = TRUE)
+      lapply(as.integer(rownames(conns)), function(i) {
+        con <- tryCatch(getConnection(i), error = function(e) NULL)
+        if (!is.null(con) && isOpen(con)) close(con)
+      })
+    }, silent = TRUE)
+  }
   
   # detach internal rbacon functions
   detach("rbacon_all")

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -1,3 +1,4 @@
+#' @export 
 Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
                     prob = 0.95, d.min = NA, d.max = NA, add.bottom = TRUE, d.by = 1,
                     seed = NA, depths.file = FALSE, depths = c(), depth.unit = "cm",

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -31,7 +31,8 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
     file.copy(fileCopy, coredir, recursive = TRUE, overwrite = FALSE)
   }
   if (ccdir == "")
-    ccdir <- system.file("extdata", package = "IntCal")
+    #ccdir <- system.file("extdata", package = "IntCal")
+    ccdir <- file.path(system.file("extdata", package = "IntCal"), "")
   
   # NOTE: validateDirectoryName was removed in newer rbacon versions.
   # If needed, add your own ccdir sanitation here.

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -33,9 +33,9 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
     ccdir <- system.file("extdata", package = "IntCal")
   
   if (packageVersion("rbacon") > "2.5.3"){
-    ccdir <- validateDirectoryName(ccdir)
+    ccdir <- rbacon:::validateDirectoryName(ccdir)
   }  else {
-    ccdir <- .validateDirectoryName(ccdir)
+    ccdir <- rbacon:::.validateDirectoryName(ccdir)
   }
   
   defaults <- system.file("extdata", defaults, package = packageName())

--- a/R/Bacon2.R
+++ b/R/Bacon2.R
@@ -131,7 +131,7 @@ Bacon2 <- function (core = "MSB2K", thick = 5, coredir = "",
             negativeages <- TRUE
   if(negativeages)
     stop("you have negative C14 ages so should select a postbomb curve", call.=FALSE)
-  info$calib <- bacon.calib(dets, info, date.res, ccdir=ccdir, cutoff=cutoff)
+  info$calib <- bacon.calib(dets, info, date.res, cutoff=cutoff)
   ###
   info$rng <- c()
   for (i in 1:length(info$calib$probs)) {

--- a/R/hamstr-bacon.R
+++ b/R/hamstr-bacon.R
@@ -54,15 +54,15 @@ hamstr_bacon <- function(
   ask = FALSE,
   slump = c(),
   remove = FALSE, ssize = 2000, th0 = c(),
-  burnin = min(500, ssize), MinAge = c(), MaxAge = c(),
+  burnin = min(500, ssize), youngest.age = c(), oldest.age = c(),
   plot.pdf = FALSE,
   close.connections = FALSE,
   verbose = FALSE, suppress.plots = TRUE,
   bacon.change.thick = FALSE
   
 ){
-  if(packageVersion("rbacon") < "2.5.2")
-    stop("hamstr_bacon requires rbacon version 2.5.2 or higher")
+  if(packageVersion("rbacon") < "2.5.6")
+    stop("hamstr_bacon requires rbacon version 2.5.6 or higher")
 
   # check inputs
   if (any(length(depth) == 0, length(obs_age) == 0, length(obs_err)== 0))


### PR DESCRIPTION
Changing internal functions to allow hamstrbacon to run with rbacon version 3.3.1 - mainly removing MinAge, MaxAge and changing behavior for closeConnection, which was fixed in rbacon v 2.5.6.